### PR TITLE
Update Clock.h - fix casting error

### DIFF
--- a/src/Clock.h
+++ b/src/Clock.h
@@ -6,7 +6,7 @@ class Clock
 public:
   void readClock()
   {
-    long unixTime = (long)rack::system::getUnixTime();
+    time_t unixTime = (time_t)rack::system::getUnixTime();
 
     // extract the time from the unix time
     struct tm *timeinfo = std::localtime(&unixTime);


### PR DESCRIPTION
Using ``time_t`` instead of ``long`` should be good here.
```
src/Clock.h:12:42: error: cannot convert 'long int*' to 'const time_t*' {aka 'const long long int*'}
```